### PR TITLE
fix: remove double headers and redundant descriptions from CLI reference docs

### DIFF
--- a/cli-reference/agent.mdx
+++ b/cli-reference/agent.mdx
@@ -4,10 +4,6 @@ description: Managing ElizaOS agents through the CLI - list, configure, start, s
 icon: robot
 ---
 
-# Agent Command
-
-Manage ElizaOS agents.
-
 <Tabs>
   <Tab title="Overview">
     ## Usage

--- a/cli-reference/create.mdx
+++ b/cli-reference/create.mdx
@@ -4,10 +4,6 @@ description: Initialize a new project, plugin, or agent with an interactive setu
 icon: circle-plus
 ---
 
-# Create Command
-
-Initialize a new project, plugin, or agent.
-
 <Tabs>
   <Tab title="Overview">
     ## Usage

--- a/cli-reference/dev.mdx
+++ b/cli-reference/dev.mdx
@@ -4,10 +4,6 @@ description: Run ElizaOS projects in development mode with hot reloading and deb
 icon: code
 ---
 
-# Dev Command
-
-Start the project or plugin in development mode with auto-rebuild, detailed logging, and file change detection.
-
 <Tabs>
   <Tab title="Overview">
     ## Usage

--- a/cli-reference/env.mdx
+++ b/cli-reference/env.mdx
@@ -4,10 +4,6 @@ description: Configure environment variables and API keys for ElizaOS projects
 icon: gear
 ---
 
-# Environment Command
-
-Manage environment variables and secrets.
-
 <Tabs>
   <Tab title="Overview">
     ## Usage

--- a/cli-reference/monorepo.mdx
+++ b/cli-reference/monorepo.mdx
@@ -4,10 +4,6 @@ description: Clone the ElizaOS monorepo for development or contribution
 icon: code-branch
 ---
 
-# Monorepo Command
-
-Clone ElizaOS monorepo from a specific branch, defaults to develop.
-
 ## Usage
 
 ```bash

--- a/cli-reference/overview.mdx
+++ b/cli-reference/overview.mdx
@@ -4,10 +4,6 @@ description: Comprehensive guide to the ElizaOS Command Line Interface (CLI) too
 icon: terminal
 ---
 
-# ElizaOS CLI
-
-The ElizaOS Command Line Interface (CLI) provides a comprehensive set of tools to create, manage, and interact with ElizaOS projects and agents.
-
 ## Installation
 
 Install the ElizaOS CLI globally using Bun:

--- a/cli-reference/plugins.mdx
+++ b/cli-reference/plugins.mdx
@@ -4,10 +4,6 @@ description: Manage ElizaOS plugins within a project - list, add, remove
 icon: plug
 ---
 
-# Plugin Command
-
-Manage ElizaOS plugins.
-
 <Tabs>
   <Tab title="Overview">
     ## Usage

--- a/cli-reference/publish.mdx
+++ b/cli-reference/publish.mdx
@@ -4,8 +4,6 @@ description: Publish a plugin to npm, create a GitHub repository, and submit to 
 icon: cloud-arrow-up
 ---
 
-# Publish Command
-
 The `elizaos publish` command is the all-in-one tool for releasing your plugin. It handles packaging, publishing to npm, creating a source repository, and submitting your plugin to the official ElizaOS registry for discovery.
 
 <Tabs>

--- a/cli-reference/start.mdx
+++ b/cli-reference/start.mdx
@@ -4,10 +4,6 @@ description: Launch and manage ElizaOS projects and agents in production mode
 icon: play
 ---
 
-# Start Command
-
-Start the Eliza agent server.
-
 <Tabs>
   <Tab title="Overview">
     ## Usage

--- a/cli-reference/tee.mdx
+++ b/cli-reference/tee.mdx
@@ -4,8 +4,6 @@ description: Manage TEE deployments on ElizaOS
 icon: shield
 ---
 
-# ElizaOS TEE
-
 The `tee` command provides access to Trusted Execution Environment (TEE) deployment and management capabilities through integrated vendor CLIs.
 
 ## Overview

--- a/cli-reference/test.mdx
+++ b/cli-reference/test.mdx
@@ -4,10 +4,6 @@ description: Run and manage tests for ElizaOS projects and plugins
 icon: flask
 ---
 
-# Test Command
-
-Run tests for Eliza agent projects and plugins.
-
 <Tabs>
   <Tab title="Overview">
     ## Usage

--- a/cli-reference/update.mdx
+++ b/cli-reference/update.mdx
@@ -4,10 +4,6 @@ description: Update your project's ElizaOS dependencies and CLI to the latest pu
 icon: arrows-rotate
 ---
 
-# Update Command
-
-Update ElizaOS CLI and project dependencies.
-
 <Tabs>
   <Tab title="Overview">
     ## Usage


### PR DESCRIPTION
## Summary
- Remove H1 headings that duplicated frontmatter titles in all CLI reference documentation
- Remove redundant description lines that duplicated frontmatter descriptions
- Ensures consistency with Mintlify documentation standards

## Changes
- **Removed double headers**: All H1 headings (`# Title`) were removed since Mintlify automatically generates H1 from frontmatter titles
- **Removed redundant descriptions**: Standalone description lines after frontmatter were removed to avoid duplication
- **Files updated**: All 12 CLI reference documentation files

## Files Modified
- `cli-reference/agent.mdx`
- `cli-reference/create.mdx`
- `cli-reference/dev.mdx`
- `cli-reference/env.mdx`
- `cli-reference/monorepo.mdx`
- `cli-reference/overview.mdx`
- `cli-reference/plugins.mdx`
- `cli-reference/publish.mdx`
- `cli-reference/start.mdx`
- `cli-reference/tee.mdx`
- `cli-reference/test.mdx`
- `cli-reference/update.mdx`

## Test Plan
- [x] Verified all double headers are removed
- [x] Verified redundant descriptions are removed
- [x] Content structure remains intact
- [x] Frontmatter descriptions are comprehensive and serve as the sole description

🤖 Generated with [Claude Code](https://claude.ai/code)