### PR TITLE
Reformatting introduction page and changing starting page to quickstart

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -15,7 +15,7 @@
         "groups": [
           {
             "group": "Get Started",
-            "pages": ["index", "quickstart", "development"]
+            "pages": ["quickstart", "introduction", "development"]
           },
           {
             "group": "Core Concepts",

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,22 +1,13 @@
 ---
 title: Introduction
-description: "Welcome to elizaos - Your AI Agent Framework"
+description: "Welcome to elizaOS - Your AI Agent Framework"
 ---
 
-<img
-  className="block dark:hidden"
-  src="/images/hero-light.png"
-  alt="Hero Light"
-/>
-<img
-  className="hidden dark:block"
-  src="/images/hero-dark.png"
-  alt="Hero Dark"
-/>
+
 
 ## Getting Started
 
-Build powerful AI agents with elizaos - a flexible framework for creating autonomous AI systems.
+Build powerful AI agents with elizaOS - a flexible framework for creating autonomous AI systems.
 
 <CardGroup cols={2}>
   <Card
@@ -37,7 +28,7 @@ Build powerful AI agents with elizaos - a flexible framework for creating autono
 
 ## Core Features
 
-Explore the powerful capabilities that make elizaos the choice for AI agent development.
+Explore the powerful capabilities that make elizaOS the choice for AI agent development.
 
 <CardGroup cols={2}>
   <Card
@@ -52,7 +43,7 @@ Explore the powerful capabilities that make elizaos the choice for AI agent deve
     icon="terminal"
     href="/api-reference/agents/create-a-new-agent"
   >
-    Complete API documentation for all elizaos modules
+    Complete API documentation for all elizaOS modules
   </Card>
   <Card
     title="Plugins"


### PR DESCRIPTION
Moved introduction page out of `index.mdx` and into `introduction.mdx`, adjusted capitalization of elizaOS on introduction page, and made `quickstart.mdx` the default page.