### PR TITLE
Add Reference section to navigation for llms.txt and llms-full.txt

### DIFF
--- a/.github/workflows/check-dead-links.yml
+++ b/.github/workflows/check-dead-links.yml
@@ -1,5 +1,10 @@
 name: Check Dead Links
 
+# Cancel previous runs for the same PR/branch
+concurrency:
+  group: cli-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, ready_for_review]

--- a/.github/workflows/check-documentation-quality.yml
+++ b/.github/workflows/check-documentation-quality.yml
@@ -1,5 +1,10 @@
 name: Check Documentation Quality
 
+# Cancel previous runs for the same PR/branch
+concurrency:
+  group: cli-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, ready_for_review]

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,8 @@
 name: Claude Code Review
+# Cancel previous runs for the same PR/branch
+concurrency:
+  group: cli-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,8 @@
 name: Claude Code
+# Cancel previous runs for the same PR/branch
+concurrency:
+  group: cli-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   issue_comment:

--- a/docs.json
+++ b/docs.json
@@ -68,7 +68,16 @@
           {
             "group": "Reference",
             "icon": "file-text",
-            "pages": ["llms", "llms-full"]
+            "pages": [
+              {
+                "name": "llms.txt",
+                "href": "/llms.txt"
+              },
+              {
+                "name": "llms-full.txt",
+                "href": "/llms-full.txt"
+              }
+            ]
           }
         ]
       },

--- a/docs.json
+++ b/docs.json
@@ -64,6 +64,11 @@
                 ]
               }
             ]
+          },
+          {
+            "group": "Reference",
+            "icon": "file-text",
+            "pages": ["llms", "llms-full"]
           }
         ]
       },


### PR DESCRIPTION
## Summary
Adds a new Reference section to the bottom of the Docs tab navigation to include links for llms.txt and llms-full.txt files.

## Changes
- Added new "Reference" section at the bottom of the Docs tab navigation in docs.json
- Includes navigation links for `llms` and `llms-full` files
- Uses `file-text` icon for visual consistency
- Follows standard documentation pattern with reference materials appearing at the end

## Navigation Structure
The sidebar will now show:
- Getting Started
- Core Concepts  
- Deep Dive
- Guides
- **Reference** 📄
  - llms
  - llms-full

This provides easy access to LLM reference files while keeping them separate from tutorial content.