### PR TITLE
fix: broken links for plugins

### DIFF
--- a/plugin-registry/overview.mdx
+++ b/plugin-registry/overview.mdx
@@ -13,15 +13,15 @@ The elizaOS plugin system is a comprehensive extension mechanism that allows dev
 elizaOS includes essential core plugins that provide foundational functionality:
 
 <CardGroup cols={2}>
-  <Card title="Bootstrap Plugin" icon="rocket" href="/plugins/bootstrap">
+  <Card title="Bootstrap Plugin" icon="rocket" href="/plugin-registry/bootstrap">
     The core message handler and event system for elizaOS agents. Provides essential functionality for message processing, knowledge management, and basic agent operations.
   </Card>
   
-  <Card title="SQL Plugin" icon="database" href="/plugins/sql">
+  <Card title="SQL Plugin" icon="database" href="/plugin-registry/sql">
     Database integration and management for elizaOS. Features automatic schema migrations, multi-database support, and a sophisticated plugin architecture.
   </Card>
   
-  <Card title="Knowledge Plugin" icon="brain" href="/plugins/knowledge">
+  <Card title="Knowledge Plugin" icon="brain" href="/plugin-registry/knowledge">
     Advanced knowledge base and RAG system for elizaOS. Provides semantic search, contextual embeddings, and intelligent document processing.
   </Card>
 </CardGroup>
@@ -31,11 +31,11 @@ elizaOS includes essential core plugins that provide foundational functionality:
 Blockchain and DeFi integrations for Web3 functionality:
 
 <CardGroup cols={2}>
-  <Card title="EVM Plugin" icon="cube" href="/plugins/defi/evm">
+  <Card title="EVM Plugin" icon="cube" href="/plugin-registry/defi/evm">
     Multi-chain EVM support with token transfers, swaps, bridging, and governance across 30+ networks including Ethereum, Base, Arbitrum, and more.
   </Card>
   
-  <Card title="Solana Plugin" icon="bolt" href="/plugins/defi/solana">
+  <Card title="Solana Plugin" icon="bolt" href="/plugin-registry/defi/solana">
     High-performance Solana blockchain integration with SOL/SPL transfers, Jupiter swaps, and real-time portfolio tracking.
   </Card>
 </CardGroup>
@@ -45,19 +45,19 @@ Blockchain and DeFi integrations for Web3 functionality:
 Connect your agent to popular platforms:
 
 <CardGroup cols={2}>
-  <Card title="Discord" icon="discord" href="/plugins/platform/discord">
+  <Card title="Discord" icon="discord" href="/plugin-registry/platform/discord">
     Full Discord integration with voice, commands, and rich interactions.
   </Card>
   
-  <Card title="Telegram" icon="telegram" href="/plugins/platform/telegram">
+  <Card title="Telegram" icon="telegram" href="/plugin-registry/platform/telegram">
     Telegram bot functionality with inline keyboards and media support.
   </Card>
   
-  <Card title="Twitter" icon="twitter" href="/plugins/platform/twitter">
+  <Card title="Twitter" icon="twitter" href="/plugin-registry/platform/twitter">
     Twitter/X integration for posting, replying, and timeline management.
   </Card>
   
-  <Card title="Farcaster" icon="message" href="/plugins/platform/farcaster">
+  <Card title="Farcaster" icon="message" href="/plugin-registry/platform/farcaster">
     Farcaster social network integration with casting and engagement.
   </Card>
 </CardGroup>
@@ -67,15 +67,15 @@ Connect your agent to popular platforms:
 Choose from various language model providers:
 
 <CardGroup cols={3}>
-  <Card title="OpenAI" icon="openai" href="/plugins/llm/openai">
+  <Card title="OpenAI" icon="openai" href="/plugin-registry/llm/openai">
     GPT-4, GPT-3.5, and other OpenAI models.
   </Card>
   
-  <Card title="Anthropic" icon="robot" href="/plugins/llm/anthropic">
+  <Card title="Anthropic" icon="robot" href="/plugin-registry/llm/anthropic">
     Claude 3 and other Anthropic models.
   </Card>
   
-  <Card title="OpenRouter" icon="route" href="/plugins/llm/openrouter">
+  <Card title="OpenRouter" icon="route" href="/plugin-registry/llm/openrouter">
     OpenRouter models for advanced routing and customization.
   </Card>
 </CardGroup>
@@ -84,7 +84,7 @@ Choose from various language model providers:
 
 Explore the complete collection of community-contributed plugins in our dedicated registry.
 
-<Card title="Browse Plugin Registry" icon="puzzle-piece" href="/plugins/registry">
+<Card title="Browse Plugin Registry" icon="puzzle-piece" href="/plugin-registry/registry">
   Access the full plugin registry with real-time updates, detailed plugin information, version tracking, and easy installation instructions for all v1 compatible elizaOS plugins.
 </Card>
 


### PR DESCRIPTION
fixed broken links in the plugin registry overview,  plugins -> plugin-registry