### PR TITLE
fix docs for llms button

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -21,7 +21,7 @@
         {
           "anchor": "Docs for LLMs",
           "icon": "robot",
-          "href": "https://eliza.how/llms-full.txt"
+          "href": "https://docs.elizaos.ai/llms-full.txt"
         }
       ]
     },
@@ -415,19 +415,7 @@
       "view",
       "chatgpt",
       "claude",
-      {
-        "title": "Ask Perplexity",
-        "description": "Ask Perplexity about the current page",
-        "href": {
-          "base": "https://www.perplexity.ai/search",
-          "query": [
-            {
-              "key": "q",
-              "value": "Ask question about https://eliza.how$path.md"
-            }
-          ]
-        }
-      }
+      "perplexity"
     ]
   }
 }


### PR DESCRIPTION
docs-for-llms button was incorrectly referencing the wrong static URL. I fixed it and also fixed a small inconsistency with the way 'open in perplexity' function was set up.