### PR TITLE
fix: broken links in plugin-registry

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -314,7 +314,7 @@
                 "group": "Discord",
                 "pages": [
                   "plugin-registry/platform/discord",
-                  "plugin-registry/platform/discord/complete-documentation",
+                  "plugin-registry/platform/discord/developer-guide",
                   "plugin-registry/platform/discord/event-flow",
                   "plugin-registry/platform/discord/examples",
                   "plugin-registry/platform/discord/testing-guide"
@@ -324,7 +324,7 @@
                 "group": "Telegram",
                 "pages": [
                   "plugin-registry/platform/telegram",
-                  "plugin-registry/platform/telegram/complete-documentation",
+                  "plugin-registry/platform/telegram/developer-guide",
                   "plugin-registry/platform/telegram/message-flow",
                   "plugin-registry/platform/telegram/examples",
                   "plugin-registry/platform/telegram/testing-guide"
@@ -334,7 +334,7 @@
                 "group": "Twitter",
                 "pages": [
                   "plugin-registry/platform/twitter",
-                  "plugin-registry/platform/twitter/complete-documentation",
+                  "plugin-registry/platform/twitter/developer-guide",
                   "plugin-registry/platform/twitter/timeline-flow",
                   "plugin-registry/platform/twitter/examples",
                   "plugin-registry/platform/twitter/testing-guide"

--- a/plugin-registry/platform/discord.mdx
+++ b/plugin-registry/platform/discord.mdx
@@ -8,10 +8,10 @@ The @elizaos/plugin-discord enables your elizaOS agent to operate as a Discord b
 
 ## 📚 Documentation
 
-- **[Complete Documentation](./complete-documentation.mdx)** - Detailed technical reference
-- **[Event Flow](./event-flow.mdx)** - Visual guide to Discord event processing
-- **[Examples](./examples.mdx)** - Practical implementation examples
-- **[Testing Guide](./testing-guide.mdx)** - Testing strategies and patterns
+- **[Developer Guide](/plugin-registry/platform/discord/developer-guide)** - Detailed technical reference
+- **[Event Flow](/plugin-registry/platform/discord/event-flow)** - Visual guide to Discord event processing
+- **[Examples](/plugin-registry/platform/discord/examples)** - Practical implementation examples
+- **[Testing Guide](/plugin-registry/platform/discord/testing-guide)** - Testing strategies and patterns
 
 ## 🔧 Configuration
 

--- a/plugin-registry/platform/discord/developer-guide.mdx
+++ b/plugin-registry/platform/discord/developer-guide.mdx
@@ -749,6 +749,6 @@ Common debug points:
 ## Support
 
 For issues and questions:
-- 📚 Check the [examples](./examples.mdx)
-- 💬 Join our [Discord community](https://discord.gg/elizaos)
-- 🐛 Report issues on [GitHub](https://github.com/elizaos/eliza/issues)
+- 📚 Check the [examples](/plugin-registry/platform/discord/examples)
+- 💬 Join our [Discord community](https://discord.com/invite/ai16z)
+- 🐛 Report issues on [GitHub](https://github.com/elizaos-plugins/plugin-discord/issues)

--- a/plugin-registry/platform/farcaster.mdx
+++ b/plugin-registry/platform/farcaster.mdx
@@ -8,10 +8,10 @@ The @elizaos/plugin-farcaster enables your elizaOS agent to interact with the Fa
 
 ## 📚 Documentation
 
-- **[Developer Guide](./farcaster/developer-guide.mdx)** - Detailed technical reference
-- **[Cast Flow](./farcaster/cast-flow.mdx)** - Visual guide to cast processing
-- **[Examples](./farcaster/examples.mdx)** - Practical implementation examples
-- **[Testing Guide](./farcaster/testing-guide.mdx)** - Testing strategies and patterns
+- **[Developer Guide](/plugin-registry/platform/farcaster/developer-guide)** - Detailed technical reference
+- **[Cast Flow](/plugin-registry/platform/farcaster/cast-flow)** - Visual guide to cast processing
+- **[Examples](/plugin-registry/platform/farcaster/examples)** - Practical implementation examples
+- **[Testing Guide](/plugin-registry/platform/farcaster/testing-guide)** - Testing strategies and patterns
 
 ## 🔧 Configuration
 

--- a/plugin-registry/platform/telegram.mdx
+++ b/plugin-registry/platform/telegram.mdx
@@ -8,10 +8,10 @@ The @elizaos/plugin-telegram enables your elizaOS agent to operate as a Telegram
 
 ## 📚 Documentation
 
-- **[Complete Documentation](./complete-documentation.mdx)** - Detailed technical reference
-- **[Message Flow](./message-flow.mdx)** - Visual guide to Telegram message processing
-- **[Examples](./examples.mdx)** - Practical implementation examples
-- **[Testing Guide](./testing-guide.mdx)** - Testing strategies and patterns
+- **[Developer Guide](/plugin-registry/platform/telegram/developer-guide)** - Detailed technical reference
+- **[Message Flow](/plugin-registry/platform/telegram/message-flow)** - Visual guide to Telegram message processing
+- **[Examples](/plugin-registry/platform/telegram/examples)** - Practical implementation examples
+- **[Testing Guide](/plugin-registry/platform/telegram/testing-guide)** - Testing strategies and patterns
 
 ## 🔧 Configuration
 

--- a/plugin-registry/platform/telegram/developer-guide.mdx
+++ b/plugin-registry/platform/telegram/developer-guide.mdx
@@ -855,6 +855,6 @@ describe('Telegram Plugin Tests', () => {
 ## Support
 
 For issues and questions:
-- 📚 Check the [examples](./examples.mdx)
-- 💬 Join our [Discord community](https://discord.gg/elizaos)
-- 🐛 Report issues on [GitHub](https://github.com/elizaos/eliza/issues)
+- 📚 Check the [examples](/plugin-registry/platform/telegram/examples)
+- 💬 Join our [Discord community](https://discord.com/invite/ai16z)
+- 🐛 Report issues on [GitHub](https://github.com/elizaos-plugins/plugin-telegram/issues)

--- a/plugin-registry/platform/twitter.mdx
+++ b/plugin-registry/platform/twitter.mdx
@@ -8,10 +8,10 @@ The @elizaos/plugin-twitter enables your elizaOS agent to interact with Twitter/
 
 ## Documentation
 
-- **[Complete Documentation](./complete-documentation.mdx)** - Detailed technical reference
-- **[Timeline Flow](./timeline-flow.mdx)** - Visual guide to timeline processing
-- **[Examples](./examples.mdx)** - Practical implementation examples
-- **[Testing Guide](./testing-guide.mdx)** - Testing strategies and patterns
+- **[Developer Guide](/plugin-registry/platform/twitter/developer-guide)** - Detailed technical reference
+- **[Timeline Flow](/plugin-registry/platform/twitter/timeline-flow)** - Visual guide to timeline processing
+- **[Examples](/plugin-registry/platform/twitter/examples)** - Practical implementation examples
+- **[Testing Guide](/plugin-registry/platform/twitter/testing-guide)** - Testing strategies and patterns
 
 ## Configuration
 

--- a/plugin-registry/platform/twitter/developer-guide.mdx
+++ b/plugin-registry/platform/twitter/developer-guide.mdx
@@ -945,6 +945,6 @@ class MemoryManager {
 ## Support
 
 For issues and questions:
-- 📚 Check the [examples](./examples.mdx)
-- 💬 Join our [Discord community](https://discord.gg/elizaos)
-- 🐛 Report issues on [GitHub](https://github.com/elizaos/eliza/issues)
+- 📚 Check the [examples](/plugin-registry/platform/twitter/examples)
+- 💬 Join our [Discord community](https://discord.com/invite/ai16z)
+- 🐛 Report issues on [GitHub](https://github.com/elizaos-plugins/plugin-twitter/issues)


### PR DESCRIPTION
fixes for:

- broken links in plugin-registry for farcaster, telegram, discord, and telegram
- renamed some pages within each plugin that were named the old names to be consistent
- fixed the github issues links to go to the specific plugin instead of the overall elizaos repo
- fixed an incorrect discord invite link