### PR TITLE
fix(docs): update outdated links in documentation

### DIFF
--- a/plugin-registry/bootstrap.mdx
+++ b/plugin-registry/bootstrap.mdx
@@ -3,24 +3,20 @@ title: "Message Processing Core"
 description: "Comprehensive documentation for @elizaos/plugin-bootstrap - the core message handler and event system for elizaOS agents"
 ---
 
-
 Welcome to the comprehensive documentation for the `@elizaos/plugin-bootstrap` package - the core message handler and event system for elizaOS agents.
 
 ## 📚 Documentation Structure
 
 ### Core Documentation
 
-- **[Complete Developer Documentation](/plugins/bootstrap/complete-documentation.mdx)**  
+- **[Complete Developer Documentation](/plugin-registry/bootstrap/complete-documentation)**  
   Comprehensive guide covering all components, architecture, and implementation details
 
-- **[Message Flow Diagram](/plugins/bootstrap/message-flow.mdx)**  
+- **[Message Flow Diagram](/plugin-registry/bootstrap/message-flow)**  
   Step-by-step breakdown of how messages flow through the system with visual diagrams
 
-- **[Examples & Recipes](/plugins/bootstrap/examples.mdx)**  
+- **[Examples & Recipes](/plugin-registry/bootstrap/examples)**  
   Practical examples, code snippets, and real-world implementations
 
-- **[Testing Guide](/plugins/bootstrap/testing-guide.mdx)**  
+- **[Testing Guide](/plugin-registry/bootstrap/testing-guide)**  
   Testing patterns, best practices, and comprehensive test examples
-
-
-


### PR DESCRIPTION
### Summary
This pull request updates several outdated or broken links in the documentation.  
The affected files have been updated to point to the correct and current URLs.

### Changes
- Replaced old links with new, working URLs.
- Verified that the updated links render properly in local preview.

