### PR TITLE
feat: add discord/community cta

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -395,7 +395,14 @@
     "dark": "/logo/dark.png"
   },
   "navbar": {
-    "links": [],
+    "links": [
+      {
+        "label": "Join Community",
+        "href": "https://discord.gg/ai16z",
+        "icon": "discord",
+        "style": "primary"
+      }
+    ],
     "primary": {
       "type": "github",
       "href": "https://github.com/elizaos/eliza"
@@ -418,6 +425,11 @@
       "og:image": "/images/eliza-og.png",
       "twitter:card": "summary_large_image",
       "twitter:image": "/images/eliza-og.png"
+    }
+  },
+  "analytics": {
+    "posthog": {
+      "apiKey": "phc_YOUR_POSTHOG_API_KEY"
     }
   },
   "contextual": {

--- a/style.css
+++ b/style.css
@@ -243,3 +243,14 @@ a[href*="llms-full.txt"] svg[style*="robot.svg"] {
   pointer-events: none;
   z-index: 0;
 }
+
+/* Navbar "Join Community" button hover - match GitHub button blue text */
+a[href*="discord.gg"]:hover {
+  color: #0B35F1 !important;
+}
+
+/* Make Discord icon turn blue on hover (Mintlify uses mask-based icons) */
+a[href*="discord.gg"]:hover * {
+  color: #0B35F1 !important;
+  background-color: currentColor !important;
+}


### PR DESCRIPTION
add a more prominent cta for community to join discord -- added to top right in prime cta area